### PR TITLE
Fix pip installation

### DIFF
--- a/morphsnakes.py
+++ b/morphsnakes.py
@@ -65,7 +65,6 @@ __all__ = [
 ]
 
 __version__ = (2, 1, 1)
-__version_str__ = ".".join(map(str, __version__))
 
 
 class _fcycle(object):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="BSD 3-clause",
     # packages=["morphsnakes"],
     py_modules=["morphsnakes"],
-    requires=['numpy', 'scipy'],
+    install_requires=['numpy', 'scipy'],
     long_description="""
     The Morphological Snakes are a family of methods for image-guided 
     evolution of curves and surfaces represented as a level-set of an embedding 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,23 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from morphsnakes import __version_str__
+
+def get_version():
+    """ Avoid importing package before dependencies are installed. """
+    values = {}
+    with open("morphsnakes.py", "r") as f:
+        for line in f.readlines():
+            if "__version__" in line:
+                exec(line, {}, values)
+                break
+
+    version = values.get("__version__", (0, 1, 0))
+    return ".".join(map(str, version))
+
 
 setup(
     name="morphsnakes",
-    version=__version_str__,
+    version=get_version(),
     description="Morphological Snakes",
     author="Pablo Márquez Neila",
     author_email="pablo.marquez@artorg.unibe.ch",


### PR DESCRIPTION
Suggested changes to fix `pip`-based installation (closes #31):

1. Modify setup argument to automatically install dependencies (`requires` -> `install_requires`)
2. Work around to avoid importing `morphsnakes` in `setup.py`: this causes an issue if dependencies are not already available (you try to import packages before they are actually installed)